### PR TITLE
docs: update README to reflect current state of 1st gen os2display project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> [!Important]
+> 
+> ### This project is no longer actively maintained.
+> 
+> The source code in this repository is no longer maintained. It has been superseded by [version 2](https://os2display.github.io/display-docs/), which offers improved features and better support.
+> 
+> Thank you to all who have contributed to this project. We recommend transitioning to [Os2Display version 2](https://os2display.github.io/display-docs/) for continued support and updates.
+> 
+> **Final Release**: The final stable release is version [2.1.0](https://github.com/os2display/horizon-template-bundle/releases/tag/2.1.0)
+<br>
+
 # horizon-template-bundle
 
 Contains templates for os2display.


### PR DESCRIPTION
@tuj Added an "Important note" similar to the PR to all the other `.*-bundle$` repos in the os2display org.